### PR TITLE
[PLAT-425] Fix reset! to not send DISCARD ALL

### DIFF
--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -117,6 +117,17 @@ module ActiveRecord
         Float::INFINITY
       end
 
+      def reset!
+        @lock.synchronize do
+          clear_cache!
+          reset_transaction
+          unless @connection.transaction_status == ::PG::PQTRANS_IDLE
+            @connection.query "ROLLBACK"
+          end
+          configure_connection
+        end
+      end
+
     private
 
       # Copied from PostgreSQL with minor registration changes.  If broken out, could override segments, etc

--- a/spec/redshift/connection_spec.rb
+++ b/spec/redshift/connection_spec.rb
@@ -13,4 +13,10 @@ RSpec.describe ActiveRecord::ConnectionAdapters::RedshiftAdapter, type: :model d
         %i( primary_key string text integer float decimal datetime time date bigint boolean )
     end
   end
+
+  describe '#reset!' do
+    it do
+      expect { subject.reset! }.to_not raise_exception(PG::SyntaxError)
+    end
+  end
 end


### PR DESCRIPTION
The postgresql adaptor sends "DISCARD ALL", which is not supported by Redshift.