### PR TITLE
Changed not to reference A when schema dump

### DIFF
--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -128,6 +128,16 @@ module ActiveRecord
         end
       end
 
+      def extension_enabled?(name)
+        return false unless supports_extensions?
+        super
+      end
+
+      def extensions
+        return [] unless supports_extensions?
+        super
+      end
+
     private
 
       # Copied from PostgreSQL with minor registration changes.  If broken out, could override segments, etc


### PR DESCRIPTION
Rails now only supports postgres 9.1 and higher.  Then, ActiveRecord no longer check the value of `supports_extensions?`
See: https://github.com/rails/rails/commit/5cd6f1792e9710979ce53943c28b2b38dae34e98

But Redshift still dosen't support extensions and dosen't have `pg_extensions`  tables.
This pull request is override methods related to extensions in PostgresqlAdapter  to solve that ploblem