### PR TITLE
RedShift column type `timestamptz` should be bound to Ruby's `Type::Time`

### DIFF
--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -144,7 +144,7 @@ module ActiveRecord
         m.alias_type 'name', 'varchar'
         m.alias_type 'bpchar', 'varchar'
         m.register_type 'bool', Type::Boolean.new
-        m.alias_type 'timestamptz', 'timestamp'
+        m.register_type 'timestamptz', Type::Time.new
         m.register_type 'date', Type::Date.new
 
         m.register_type 'timestamp' do |_, _, sql_type|


### PR DESCRIPTION
To keep consistency of binding from `Type::Time` to `timestamptz`.

In postshift, `Type::time` is used as `timestamptz` but, `timestamptz` is aliased as `timestamp`, thus it is bound to `Type::DateTime`.
It should be bound to `Type::time`.
https://github.com/ValiMail/postshift/commit/f13f7d382866e892a9ae0808bcf5000b35fa525a